### PR TITLE
Remove network interface addresses flush

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,7 +67,6 @@
 - name: restart devices
   shell: >
     [ -n "$(ifquery --list --exclude=lo)" ] && udevadm settle
-    && ip addr flush {{ item.item.device }}
     && (ifdown {{ item.item.device }} --exclude=lo || true) && ifup {{ item.item.device }} --exclude=lo
   when: item.changed and item.item.auto | default(true)
   with_items: "{{ _network_interfaces_configuration_result.results | default([]) }}"


### PR DESCRIPTION
This is not necessary for changes to be taken into account and a flush prevent
multiple IP addresses to be setup on the same interface (eth0:0, eth0:1, ...).