### PR TITLE
Add Support for Bonded Interfaces + Add Missing Pre/Post Hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ None
 
 * `network_interfaces_interfaces.{n}.pre-up`: [optional, default: `[]`]: List of pre-up script lines
 * `network_interfaces_interfaces.{n}.up`: [optional, default: `[]`]: List of up script lines
+* `network_interfaces_interfaces.{n}.post-up`: [optional, default: `[]`]: List of post-up script lines
+* `network_interfaces_interfaces.{n}.pre-down`: [optional, default: `[]`]: List of pre-down script lines
 * `network_interfaces_interfaces.{n}.down`: [optional, default: `[]`]: List of down script lines
 * `network_interfaces_interfaces.{n}.post-down`: [optional, default: `[]`]: List of post-down script lines
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ None
 * `network_interfaces_interfaces.{n}.bridge.maxwait`: [optional]: Maximum time to wait for the bridge ports to get to the forwarding status
 * `network_interfaces_interfaces.{n}.bridge.waitport`: [optional]: Maximum time to wait for the specified ports to become available
 
+##### Bond
+
+* `network_interfaces_interfaces.{n}.bond`: [optional, default: `{}`]: Bond declarations
+* `network_interfaces_interfaces.{n}.bond.mode`: [optional]: Bonding mode. One of "active-backup", "balance-slb", or "balance-tcp".
+* `network_interfaces_interfaces.{n}.bond.miimon`: [optional]: Specifies the MII link monitoring frequency in milliseconds.
+* `network_interfaces_interfaces.{n}.bond.master`: [optional]: The name of the device that should act as bond master.
+* `network_interfaces_interfaces.{n}.bond.slaves`: [optional]: A list of devices to be used as bond slave.
+* `network_interfaces_interfaces.{n}.bond.lacp-rate`: [optional]: Option specifying the rate in of transmission of LACPDU packets in 802.3ad mode.
+* `network_interfaces_interfaces.{n}.bond.xmit-hash-policy`: [optional]: The transmit hash policy to use for slave selection in balance-xor and 802.3ad modes.
+
 ##### Inline hook scripts
 
 * `network_interfaces_interfaces.{n}.pre-up`: [optional, default: `[]`]: List of pre-up script lines

--- a/templates/etc/network/interfaces.d/device.j2
+++ b/templates/etc/network/interfaces.d/device.j2
@@ -48,10 +48,10 @@ iface {{ item.device }} {{ item.family | default('inet', true) }} {{ item.method
 {%   endfor %}
 {% endif %}
 
-{%- if ['pre-up', 'up', 'down', 'post-down'] | intersect(item.keys()) %}
+{%- if ['pre-up','up', 'post-up', 'pre-down', 'down', 'post-down'] | intersect(item.keys()) %}
 
   # hook scripts
-{%   for key in ['pre-up', 'up', 'down', 'post-down'] %}
+{%   for key in ['pre-up','up', 'post-up', 'pre-down', 'down', 'post-down'] %}
 {%     if key in item %}
 {%       for value in item[key] %}
   {{ key }} {{ value }}

--- a/templates/etc/network/interfaces.d/device.j2
+++ b/templates/etc/network/interfaces.d/device.j2
@@ -29,6 +29,16 @@ iface {{ item.device }} {{ item.family | default('inet', true) }} {{ item.method
 {%   endfor %}
 {% endif %}
 
+{%- if item.bond is defined -%}
+
+  # bond settings
+{%   for key in ['mode', 'miimon', 'master', 'slaves', 'lacp-rate', 'xmit-hash-policy'] %}
+{%     if key in item.bond -%}
+  bond_{{ key }} {{ item.bond[key] }}
+{%     endif %}
+{%   endfor %}
+{% endif %}
+
 {%- if item.subnets is defined %}
 
   # additional subnets


### PR DESCRIPTION
1. Similar to the current bridge configurations, add support for bonded interfaces configuration.

2. Add missing post-up, pre-down hooks 

Readme documentation was updated accordingly. @tersmitten could you have a look please :) ?  