### PR TITLE
Avoid error when using vlan interface annotaion

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,7 +71,7 @@
 - name: restart devices
   ansible.builtin.shell: >
     [ -n "$(ifquery --list --exclude=lo)" ] && udevadm settle
-    && ip addr flush {{ item.item.device }}
+    && (ip addr flush {{ item.item.device }} || true)
     && (ifdown {{ item.item.device }} --exclude=lo || true) && ifup {{ item.item.device }} --exclude=lo
   when:
     - item.changed


### PR DESCRIPTION
Closes #17 

@tersmitten this is an alternative implementation for https://github.com/Oefenweb/ansible-network-interfaces/pull/11.
I didn't remove the address flush commend, but ensure zhat a missing interface didn't break the command chain.

Fixing this will also results in the possibility to manage VLAN interfaces. IMHO this will be an important feature for the role.